### PR TITLE
Implement summon service for carousel - snxService

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -26,7 +26,7 @@
 <snx-search-carousel titleText="Summon Carousel Test!"
                      titleLink="https://www.google.com"
                      defaultThumbnailUrl="../dist/default.png"
-                     searchUrl="https://na02.primo.exlibrisgroup.com/primaws/rest/external/pnxs?acTriggered=false&blendFacetsSeparately=false&citationTrailFilterByAvailability=true&disableCache=false&getMore=0&inst=EXLDEV1_INST&isCDSearch=false&lang=en&limit=10&newspapersActive=true&newspapersSearch=false&offset=0&otbRanking=false&pcAvailability=true&q=any,contains,artificial+intelligence&qExclude=&qInclude=&rapido=false&refEntryActive=true&rtaLinks=true&scope=MyInstitution&searchInFulltextUserSelection=true&skipDelivery=Y&sort=rank&tab=LibraryCatalog&vid=EXLDEV1_INST:Alma">
+                     searchUrl="https://rla.preview.summon.serialssolutions.com/api/search?pn=1&ho=t&include.ft.matches=t&l=en&q=climate%20change">
 </snx-search-carousel>
 </body>
 

--- a/src/document-card.ts
+++ b/src/document-card.ts
@@ -1,5 +1,5 @@
 import {html, LitElement} from "lit";
-import {customElement, property} from "lit/decorators.js";
+import {customElement, property, state} from "lit/decorators.js";
 import {styles} from './document-card-style';
 import {until} from 'lit-html/directives/until.js';
 
@@ -17,13 +17,21 @@ export class DocumentCard extends LitElement {
     @property()
     deepLink!: string;
 
+    @state()
+    thumbnailFallbackUrl: string = 'https://tinypng.com/static/images/george-account-page.webp';
+
     override render() {
         const imagePlaceHolder = html`
             <div style="background-color: ${this.getRandomColor()}"
                  class="image-place-holder"></div>`;
         const imgPromise = this.thumbnail.then((url: string) => {
             console.log(`getImageUrl returned ${url}`)
-            return html`<img src=${url} alt="">`
+            return html`
+                <img
+                        src=${url}
+                        @load=${this.imgOnLoad}
+                        @error=${this.imgOnError}
+                        alt="">`
         }).catch(() => imagePlaceHolder); //on error or no thumbnail render the image placeholder
 
         // Remove HTML tags, including <mark>
@@ -38,6 +46,19 @@ export class DocumentCard extends LitElement {
             </a>
 
         `
+    }
+
+    public imgOnLoad(e: any) {
+        console.log('Image loaded: ', e.target.naturalWidth, e.target.naturalHeight);
+        if (e.target.naturalWidth === 1 && e.target.naturalHeight === 1) {
+            console.log('Image dimensions are 1x1, likely a placeholder image.');
+            e.target.src = this.thumbnailFallbackUrl; // Set fallback source
+        }
+    }
+
+    public imgOnError(e: any) {
+        console.log('Image failed to load, applying fallback.', e.target.src);
+        e.target.src = this.thumbnailFallbackUrl; // Set fallback source
     }
 
     private getRandomColor() {

--- a/src/document-card.ts
+++ b/src/document-card.ts
@@ -21,16 +21,19 @@ export class DocumentCard extends LitElement {
         const imagePlaceHolder = html`
             <div style="background-color: ${this.getRandomColor()}"
                  class="image-place-holder"></div>`;
-        const imgPromise = this.thumbnail.then((url : string) => {
+        const imgPromise = this.thumbnail.then((url: string) => {
             console.log(`getImageUrl returned ${url}`)
             return html`<img src=${url} alt="">`
         }).catch(() => imagePlaceHolder); //on error or no thumbnail render the image placeholder
+
+        // Remove HTML tags, including <mark>
+        const cleanTitle = this.docTitle?.replace(/<\/?[^>]+(>|$)/g, '') ?? '';
         return html`
             <a href="${this.deepLink}" target="_blank" aria-label="">
                 ${until(imgPromise, imagePlaceHolder)}
                 <div class="record-details">
-                    <h3>${this.docTitle?? ''}</h3>
-                    <span>${this.publisher?? ''}</span>
+                    <h3>${cleanTitle}</h3>
+                    <span>${this.publisher ?? ''}</span>
                 </div>
             </a>
 

--- a/src/snx-search-carousel.ts
+++ b/src/snx-search-carousel.ts
@@ -2,7 +2,7 @@ import {html, LitElement} from "lit";
 import {customElement, property, state} from "lit/decorators.js";
 import {register} from 'swiper/element/bundle';
 import {SearchCarousel} from "./search-carousel";
-import { PnxService } from "./pnx-service";
+import {SnxService} from "./snx-service";
 
 register();
 
@@ -15,7 +15,7 @@ export class SnxSearchCarousel extends LitElement {
 
     @state()
     private documents: any[] = [];
-    private pnxService = new PnxService();
+    private snxService: SnxService = new SnxService();
 
     constructor() {
         super();
@@ -33,11 +33,11 @@ export class SnxSearchCarousel extends LitElement {
         try {
             const response = await fetch(this.searchUrl);
             const data = await response.json();  // Await the JSON parsing
-            this.documents = data.docs;
+            this.documents = data.documents;
         } catch (error) {
         }
 
-        console.log("here pnx: ", this.documents);
+        console.log("here snx: ", this.documents);
     }
 
     //disables shadow root for lit element otherwise swiper styling doesn't work properly
@@ -49,10 +49,10 @@ export class SnxSearchCarousel extends LitElement {
     override render() {
         if (!this.documents) {
             return html`
-                <div>Loading...</div>`;
+                <div>Error Loading Carousel Widget!!</div>`;
         }
 
-        const genericDocs = this.pnxService.transformPnxToGeneric(this.documents, this.searchUrl, this.defaultThumbnailUrl);
+        const genericDocs = this.snxService.transformSnxToGeneric(this.documents, this.defaultThumbnailUrl);
 
         return html`
             <search-carousel

--- a/src/snx-service.ts
+++ b/src/snx-service.ts
@@ -1,0 +1,35 @@
+export class SnxService {
+
+    public transformSnxToGeneric(docs: any[], defaultThumbnailUrl: string) {
+        const genericDocs = [];
+
+        // const parsedUrl = new URL(searchUrl);
+
+
+        for (const doc of docs) {
+            const genericDoc = {
+                title: doc?.title ?? '',
+                publisher: doc?.publisher ?? '',
+                thumbnail: this.getThumbnailUrl(doc, defaultThumbnailUrl),
+                deepLink: this.getDeeplink(doc)
+            }
+            genericDocs.push(genericDoc);
+        }
+        return genericDocs;
+    }
+
+
+    private async getThumbnailUrl(doc: any, defaultThumbnailUrl: string) {
+        return doc?.thumbnail_large ?? doc.thumbnail_medium ?? doc.thumbnail_small ?? defaultThumbnailUrl;
+    }
+
+    getAlmaDThumbnailBaseUrl(doc: any) {
+        const parsedUrl = new URL(doc["@id"]);
+        return `${parsedUrl.origin}/view/delivery/thumbnail`
+    }
+
+    private getDeeplink(doc: any) {
+        return doc?.link ?? '';
+    }
+
+}


### PR DESCRIPTION
- Implement a new service for summon carousel called: snxService.
- The snxService loads documents from summon API and convert them into generic docs.
- Pass proper input to document card.
- Implement a fallback mechanism for broken images in carousel - [CDI-29482](https://jira.clarivate.io/browse/CDI-29482)