### PR TITLE
Handle summon specific logic about default thumbnail in snx-service

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Run this command in order to create a minified and bundled file:
 ```bash
 rollup -c
 ```
-It will create a bundled js file called discovery-showcase.js inside the dist folder
+It will create bundled js files called pnx-discovery-showcase.bundled.js (for primo users) and snx-discovery-showcase.bundled.js (for summon users) inside the dist folder. Separate bundles are created to minimize the size of both of them, and you likely only need one or the other depending on your use case.
 
 ## More information
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -26,7 +26,7 @@
 <snx-search-carousel titleText="Summon Carousel Test!"
                      titleLink="https://www.google.com"
                      defaultThumbnailUrl="../dist/default.png"
-                     searchUrl="https://rla.preview.summon.serialssolutions.com/api/search?pn=1&ho=t&include.ft.matches=t&l=en&q=climate%20change">
+                     searchUrl="https://demo.summon.serialssolutions.com/api/search?screen_res=W1486H382&__refererURL=&pn=1&ps=10&ho=t&include.ft.matches=t&fvf%5B%5D=IsOpenAccess%2Ctrue%2Cf&fvf%5B%5D=Language%2CEnglish%2Cf&l=en&q=artificial%20intelligence&print.books.only=true">
 </snx-search-carousel>
 </body>
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,30 +9,49 @@ import {terser} from 'rollup-plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-export default {
-  input: 'search-carousel.js',
-  output: {
-    file: 'dist/discovery-showcase.bundled.js',
-    format: 'esm',
-  },
-  onwarn(warning) {
-    if (warning.code !== 'THIS_IS_UNDEFINED') {
-      console.error(`(!) ${warning.message}`);
-    }
-  },
-  plugins: [
-    replace({'Reflect.decorate': 'undefined'}),
-    resolve(),
-    terser({
-      ecma: 2017,
-      module: true,
-      warnings: true,
-      mangle: {
-        properties: {
-          regex: /^__/,
-        },
+const commonPlugins = [
+  replace({'Reflect.decorate': 'undefined'}),
+  resolve(),
+  terser({
+    ecma: 2017,
+    module: true,
+    warnings: true,
+    mangle: {
+      properties: {
+        regex: /^__/,
       },
-    }),
-    summary(),
-  ],
-};
+    },
+  }),
+  summary(),
+]
+
+export default [
+  {
+    // Configuration for pnx-search-carousel.js
+    input: 'pnx-search-carousel.js',
+    output: {
+      file: 'dist/pnx-discovery-showcase.bundled.js',
+      format: 'esm',
+    },
+    onwarn(warning) {
+      if (warning.code !== 'THIS_IS_UNDEFINED') {
+        console.error(`(!) ${warning.message}`);
+      }
+    },
+    plugins: commonPlugins,
+  },
+  {
+    // Configuration for snx-search-carousel.js
+    input: 'snx-search-carousel.js',
+    output: {
+      file: 'dist/snx-discovery-showcase.bundled.js',
+      format: 'esm',
+    },
+    onwarn(warning) {
+      if (warning.code !== 'THIS_IS_UNDEFINED') {
+        console.error(`(!) ${warning.message}`);
+      }
+    },
+    plugins: commonPlugins,
+  },
+];

--- a/src/document-card.ts
+++ b/src/document-card.ts
@@ -1,5 +1,5 @@
 import {html, LitElement} from "lit";
-import {customElement, property, state} from "lit/decorators.js";
+import {customElement, property} from "lit/decorators.js";
 import {styles} from './document-card-style';
 import {until} from 'lit-html/directives/until.js';
 
@@ -17,48 +17,26 @@ export class DocumentCard extends LitElement {
     @property()
     deepLink!: string;
 
-    @state()
-    thumbnailFallbackUrl: string = 'https://tinypng.com/static/images/george-account-page.webp';
-
     override render() {
         const imagePlaceHolder = html`
             <div style="background-color: ${this.getRandomColor()}"
-                 class="image-place-holder"></div>`;
+                 class="image-place-holder icon.sprite-m.format-sprite.format--generic_36px"></div>`;
         const imgPromise = this.thumbnail.then((url: string) => {
             console.log(`getImageUrl returned ${url}`)
             return html`
-                <img
-                        src=${url}
-                        @load=${this.imgOnLoad}
-                        @error=${this.imgOnError}
-                        alt="">`
+                <img src=${url} alt="">`
         }).catch(() => imagePlaceHolder); //on error or no thumbnail render the image placeholder
 
-        // Remove HTML tags, including <mark>
-        const cleanTitle = this.docTitle?.replace(/<\/?[^>]+(>|$)/g, '') ?? '';
         return html`
             <a href="${this.deepLink}" target="_blank" aria-label="">
                 ${until(imgPromise, imagePlaceHolder)}
                 <div class="record-details">
-                    <h3>${cleanTitle}</h3>
+                    <h3>${this.docTitle}</h3>
                     <span>${this.publisher ?? ''}</span>
                 </div>
             </a>
 
         `
-    }
-
-    public imgOnLoad(e: any) {
-        console.log('Image loaded: ', e.target.naturalWidth, e.target.naturalHeight);
-        if (e.target.naturalWidth === 1 && e.target.naturalHeight === 1) {
-            console.log('Image dimensions are 1x1, likely a placeholder image.');
-            e.target.src = this.thumbnailFallbackUrl; // Set fallback source
-        }
-    }
-
-    public imgOnError(e: any) {
-        console.log('Image failed to load, applying fallback.', e.target.src);
-        e.target.src = this.thumbnailFallbackUrl; // Set fallback source
     }
 
     private getRandomColor() {

--- a/src/image-service.ts
+++ b/src/image-service.ts
@@ -1,0 +1,33 @@
+export class ImageService {
+    public async getImageLink(imageUrl: string) {
+        return new Promise((resolve, reject) => {
+            if (!imageUrl) {
+                reject('');
+                return;
+            }
+
+            const image = new Image();
+            image.onload = () => {
+                if (image.width > 1) {
+                    resolve(imageUrl);
+                } else {
+                    reject('');
+                }
+            };
+
+            image.onerror = () => {
+                reject('');
+            };
+
+            image.src = this.handleLink(imageUrl);
+        });
+    }
+
+    public handleLink(link: string) {
+        let newLink = link;
+        if (window.location.protocol === 'https:') {
+            newLink = link.replace('http://', 'https://');
+        }
+        return newLink;
+    }
+}

--- a/src/pnx-search-carousel.ts
+++ b/src/pnx-search-carousel.ts
@@ -9,8 +9,8 @@ register();
 @customElement('pnx-search-carousel')
 export class PnxSearchCarousel extends LitElement {
     @property() searchUrl: string = '';
-    @property() titleText: string | undefined;
-    @property() titleLink: string | undefined;
+    @property() titleText: string = 'Search Results';
+    @property() titleLink: string = '';
     @property() defaultThumbnailUrl: string = '';
 
     @state()
@@ -54,7 +54,6 @@ export class PnxSearchCarousel extends LitElement {
                     .documents="${genericDocs}"
                     titleText="${this.titleText}"
                     titleLink="${this.titleLink}"
-                    defaultThumbnailUrl="${this.defaultThumbnailUrl}"
                     searchUrl="${this.searchUrl}">
             </search-carousel>`
     }

--- a/src/pnx-service.ts
+++ b/src/pnx-service.ts
@@ -1,5 +1,8 @@
+import { ImageService } from "./image-service";
 
 export class PnxService {
+
+    private imageService: ImageService = new ImageService();
 
     public transformPnxToGeneric(docs: any[], searchUrl: string, defaultThumbnailUrl: string) {
         const genericDocs = [];
@@ -126,7 +129,7 @@ export class PnxService {
         if (otherThumbnailLinks.length) {
             const promiseArray = otherThumbnailLinks.map((link: any) => {
                 this.removeLabelFromLinkUrl(link);
-                return this.getImageLink(link.linkURL);
+                return this.imageService.getImageLink(link.linkURL);
             });
 
             try {
@@ -215,7 +218,7 @@ export class PnxService {
         let syndeticsProxy = this.getSyndetixWithProxy();
         let promiseArray = syndeticsLinks.map((link: any) => {
             const imageUrl = link.linkURL.replace('https://syndetics.com/index.php?client=', syndeticsProxy);
-            return this.getImageLink(imageUrl);
+            return this.imageService.getImageLink(imageUrl);
         })
         return await this.createPromiseOnlyFailOnAllFailedResolveFirstSuccess(promiseArray);
     }
@@ -247,7 +250,7 @@ export class PnxService {
                     const returnedLink = {
                         displayLabel: 'thumbnail',
                         linkType: 'http://purl.org/pnx/linkType/thumbnail',
-                        linkURL: this.handleLink(thumbnailUrl),
+                        linkURL: this.imageService.handleLink(thumbnailUrl),
                     };
                     return returnedLink.linkURL;
                 }
@@ -338,7 +341,7 @@ export class PnxService {
     }
 
     private resolveAlmaDigitalImage(thumbnailUrl: any) {
-        return this.getImageLink(thumbnailUrl);
+        return this.imageService.getImageLink(thumbnailUrl);
     }
 
     private createLinkObj(url: any) {
@@ -347,38 +350,6 @@ export class PnxService {
             linkType: 'http://purl.org/pnx/linkType/thumbnail',
             linkURL: url
         };
-    }
-
-    private async getImageLink(imageUrl: string) {
-        return new Promise((resolve, reject) => {
-            if (!imageUrl) {
-                reject('');
-                return;
-            }
-
-            const image = new Image();
-            image.onload = () => {
-                if (image.width > 1) {
-                    resolve(imageUrl);
-                } else {
-                    reject('');
-                }
-            };
-
-            image.onerror = () => {
-                reject('');
-            };
-
-            image.src = this.handleLink(imageUrl);
-        });
-    }
-
-    private handleLink(link: string) {
-        let newLink = link;
-        if (window.location.protocol === 'https:') {
-            newLink = link.replace('http://', 'https://');
-        }
-        return newLink;
     }
 
     private getSyndetixWithProxy() {

--- a/src/search-carousel.ts
+++ b/src/search-carousel.ts
@@ -12,7 +12,6 @@ export class SearchCarousel extends LitElement {
     @property() searchUrl: string = '';
     @property() titleText: string | undefined;
     @property() titleLink: string | undefined;
-    @property() defaultThumbnailUrl: string | undefined;
 
     constructor() {
         super();

--- a/src/snx-search-carousel.ts
+++ b/src/snx-search-carousel.ts
@@ -52,7 +52,7 @@ export class SnxSearchCarousel extends LitElement {
                 <div>Error Loading Carousel Widget!!</div>`;
         }
 
-        const genericDocs = this.snxService.transformSnxToGeneric(this.documents, this.defaultThumbnailUrl);
+        const genericDocs = this.snxService.transformSnxToGeneric(this.documents, this.defaultThumbnailUrl, this.searchUrl);
 
         return html`
             <search-carousel

--- a/src/snx-search-carousel.ts
+++ b/src/snx-search-carousel.ts
@@ -9,8 +9,8 @@ register();
 @customElement('snx-search-carousel')
 export class SnxSearchCarousel extends LitElement {
     @property() searchUrl: string = '';
-    @property() titleText: string | undefined;
-    @property() titleLink: string | undefined;
+    @property() titleText: string = 'Search Results';
+    @property() titleLink: string = '';
     @property() defaultThumbnailUrl: string = '';
 
     @state()
@@ -59,7 +59,6 @@ export class SnxSearchCarousel extends LitElement {
                     .documents="${genericDocs}"
                     titleText="${this.titleText}"
                     titleLink="${this.titleLink}"
-                    defaultThumbnailUrl="${this.defaultThumbnailUrl}"
                     searchUrl="${this.searchUrl}">
             </search-carousel>`
     }

--- a/src/snx-service.ts
+++ b/src/snx-service.ts
@@ -4,7 +4,7 @@ export class SnxService {
 
     private imageService: ImageService = new ImageService();
 
-    public transformSnxToGeneric(docs: any[], defaultThumbnailUrl: string) {
+    public transformSnxToGeneric(docs: any[], defaultThumbnailUrl: string, searchUrl: string) {
         const genericDocs = [];
 
         for (const doc of docs) {
@@ -12,7 +12,7 @@ export class SnxService {
                 title: doc?.title.replace(/<\/?[^>]+(>|$)/g, '') ?? '', // Remove HTML tags, including <mark> tags
                 publisher: doc?.publisher ?? '',
                 thumbnail: this.getThumbnailLinks(doc, defaultThumbnailUrl),
-                deepLink: doc?.link ?? ''
+                deepLink: this.getDeeplink(doc, searchUrl)
             }
             genericDocs.push(genericDoc);
         }
@@ -30,6 +30,13 @@ export class SnxService {
         } catch (error) {
             throw error; // Rethrow the error for higher-level error handling
         }
+    }
+
+    private getDeeplink(doc: any, searchUrl: string) {
+        const searchUrlParts = searchUrl.split('/api');
+        const summonDomain = searchUrlParts[0];
+        const canCreateBookmark = summonDomain?.includes('summon') && doc?.bookmark || false
+        return canCreateBookmark ? `${summonDomain}/#!/search?bookMark=${doc.bookmark}` : doc?.link || '';
     }
 
 }

--- a/src/snx-service.ts
+++ b/src/snx-service.ts
@@ -1,17 +1,18 @@
+import { ImageService } from "./image-service";
+
 export class SnxService {
+
+    private imageService: ImageService = new ImageService();
 
     public transformSnxToGeneric(docs: any[], defaultThumbnailUrl: string) {
         const genericDocs = [];
 
-        // const parsedUrl = new URL(searchUrl);
-
-
         for (const doc of docs) {
             const genericDoc = {
-                title: doc?.title ?? '',
+                title: doc?.title.replace(/<\/?[^>]+(>|$)/g, '') ?? '', // Remove HTML tags, including <mark> tags
                 publisher: doc?.publisher ?? '',
-                thumbnail: this.getThumbnailUrl(doc, defaultThumbnailUrl),
-                deepLink: this.getDeeplink(doc)
+                thumbnail: this.getThumbnailLinks(doc, defaultThumbnailUrl),
+                deepLink: doc?.link ?? ''
             }
             genericDocs.push(genericDoc);
         }
@@ -19,17 +20,16 @@ export class SnxService {
     }
 
 
-    private async getThumbnailUrl(doc: any, defaultThumbnailUrl: string) {
-        return doc?.thumbnail_large ?? doc.thumbnail_medium ?? doc.thumbnail_small ?? defaultThumbnailUrl;
-    }
-
-    getAlmaDThumbnailBaseUrl(doc: any) {
-        const parsedUrl = new URL(doc["@id"]);
-        return `${parsedUrl.origin}/view/delivery/thumbnail`
-    }
-
-    private getDeeplink(doc: any) {
-        return doc?.link ?? '';
+    private async getThumbnailLinks(doc: any, defaultThumbnailUrl: string) {
+        const thumbnailLink = doc?.thumbnail_large ?? doc.thumbnail_medium ?? doc.thumbnail_small ?? defaultThumbnailUrl;
+        try {
+            if (thumbnailLink) {
+                return await this.imageService.getImageLink(thumbnailLink);
+            }
+            throw 'no thumbnail';
+        } catch (error) {
+            throw error; // Rethrow the error for higher-level error handling
+        }
     }
 
 }


### PR DESCRIPTION
- Changed URL to make it more like Primo's, but have no strong opinion. We can change it back..!
- now npx rollup -c will create two bundles, one for snx and one for pnx
- set up .nvmrc to use a version of node that is not so new but not so old (which version it is is open for discussion, but nice to suggest a version for devs)
- For fallback behavior when even the default url fails, we can use css class. Summon widget does this currently. This won't work in the stand alone index.html demo, but should work when we combine this with styles from widget builder. The problem with the onLoad function is that IF the fallback url were to return a 404, it could create an infinite loop. We could work around that for sure with a counter for tries... worth discussion
- Make sure the thumbnail function for snx returns promise like primo... this way the catch behavior in document.card will work
- Handle logic for cleaning up titles for summon in the snx service

TODO:: Go over all of this together with Ahmad... maybe meet with folks from Primo to see about merging the fork
TODO:: Update readme
TODO:: Try to break it